### PR TITLE
Add thumbnail field to entry parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ erl_crash.dump
 *.ez
 /.idea
 *.iml
+.elixir_ls

--- a/lib/parsers/rss2.ex
+++ b/lib/parsers/rss2.ex
@@ -58,6 +58,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
       author:            author || dc_creator,
       "rss2:dc:creator": entry |> element("dc:creator"),
       categories:        entry |> elements("category"),
+      "rss2:thumbnail":  entry |> element("media:thumbnail", [attr: "url"]),
       # support dc:identifier too
       id:                entry |> element("guid"),
       "rss2:guid":       entry |> element("guid"),

--- a/test/fixtures/rss2/rsn_cnn.xml
+++ b/test/fixtures/rss2/rsn_cnn.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~d/styles/rss2full.xsl"?><?xml-stylesheet type="text/css" media="screen" href="http://rss.cnn.com/~d/styles/itemcontent.css"?><rss xmlns:media="http://search.yahoo.com/mrss/" xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" version="2.0"><channel>
+<title>Business and financial news - CNNMoney.com</title>
+<link>http://money.cnn.com/?section=money_topstories</link>
+<description>CNNMoney.com, the business website of CNN, combines business news and in-depth market analysis with practical advice and answers to personal finance questions.</description>
+<language>en-us</language>
+<copyright>© 2018 Cable News Network LP, LLLP.</copyright>
+<pubDate>Thu, 04 Oct 2018 05:36:36 EDT</pubDate>
+<ttl>5</ttl>
+<image>
+<title>Business and financial news - CNNMoney.com</title>
+<link>http://money.cnn.com/?section=money_topstories</link>
+<url>http://i.cnn.net/money/images/cnnmoney_logo_144x30.gif</url>
+<width>144</width>
+<height>30</height>
+<description>CNNMoney.com, the business website of CNN, combines business news and in-depth market analysis with practical advice and answers to personal finance questions.</description>
+</image>
+<atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="http://rss.cnn.com/rss/money_topstories" /><feedburner:info uri="rss/money_topstories" /><atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/" /><item>
+<title>7 things to know before the bell</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/ojHifu3N_y4/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/04/investing/premarket-stocks-trading/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/170920161756-facebook-logo-wall-120x90.jpg" height="90" width="120" />
+<description>Read full story for latest details.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/ojHifu3N_y4" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Thu, 04 Oct 2018 05:10:29 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/04/investing/premarket-stocks-trading/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>SoftBank and Toyota want driverless cars to change the world</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/lTv_AphBRo4/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/04/technology/softbank-toyota-masa-son/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181004090933-01-toyota-softbank-1004-restricted-120x90.jpg" height="90" width="120" />
+<description>Softbank and Toyota are partnering on an effort to use autonomous vehicles and other technologies to change the world of transportation.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/lTv_AphBRo4" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Thu, 04 Oct 2018 05:27:31 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/04/technology/softbank-toyota-masa-son/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Aston Martin falls 5% in its London IPO</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/UWgkvIfP_XI/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/investing/aston-martin-ipo/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180920063734-aston-martin-ipo-restricted-120x90.jpg" height="90" width="120" />
+<description>Aston Martin is joining the ranks of listed automakers with an IPO that values the British company at more than $5 billion.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/UWgkvIfP_XI" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 23:54:24 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/investing/aston-martin-ipo/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Barnes &amp; Noble stock soars 20% as it explores a sale</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/M4Jz1s5kLs8/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/news/companies/barnes-and-noble-sale/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180906092226-barnes-and-noble-instory-120x90.jpg" height="90" width="120" />
+<description>Barnes &amp; Noble jumped more than 20% after it said it would review a sale of the troubled company.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/M4Jz1s5kLs8" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 19:59:15 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/news/companies/barnes-and-noble-sale/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Why it's time for investors to go on the defense </title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/MNBt3kv0JUY/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/investing/markets-now-investing-defense/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180912162413-nyse-traders-aug-22-120x90.jpg" height="90" width="120" />
+<description>Howard Marks, co-chairman of Oaktree Capital, explains why investors should start treading lightly.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/MNBt3kv0JUY" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 23:28:41 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/investing/markets-now-investing-defense/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>The Toys 'R' Us brand may be brought back to life</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/hmN7_lOkZnU/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/news/companies/toys-r-us-brand/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180317164312-toys-r-us-closing-sign-120x90.jpg" height="90" width="120" />
+<description>Bankrupt toy retailer tells bankruptcy court it is looking at possibly reviving the Toys 'R' Us and Babies 'R' Us brands.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/hmN7_lOkZnU" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 23:54:17 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/news/companies/toys-r-us-brand/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>The internet industry is suing California over its net neutrality law</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/SjtVyLlXRHA/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/technology/california-net-neutrality-suit/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181003145709-net-neutrality-protest-2017-file-120x90.jpg" height="90" width="120" />
+<description>Broadband trade groups and the DOJ have filed lawsuits over California's days-old law protecting net neutrality.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/SjtVyLlXRHA" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 17:46:47 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/technology/california-net-neutrality-suit/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Priyanka Chopra is helping Bumble expand in India</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/IcjguPe3G-Y/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/technology/bumble-india-priyanka-chopra/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002113026-100218-priyanka-chopra-bumble-gfx-120x90.jpg" height="90" width="120" />
+<description>It's the latest online dating app to compete for the hearts of women in India.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/IcjguPe3G-Y" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 13:40:37 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/technology/bumble-india-priyanka-chopra/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Microsoft unveils new Surface devices</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/mERKBBm5KmQ/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/technology/microsoft-surface-computers/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002131437-03-microsoft-surface-computers-120x90.jpg" height="90" width="120" />
+<description>Microsoft announced a new version of its desktop computer Surface Studio, and its first pair of smart headphones. It also announced the Surface Pro 6 and Surface Laptop 2.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/mERKBBm5KmQ" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Tue, 02 Oct 2018 23:46:21 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/technology/microsoft-surface-computers/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Getting health insurance through work now costs nearly $20,000</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/3N8m4XT0qrk/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/03/news/economy/employer-health-insurance-cost/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002174059-employer-health-benefits-120x90.jpg" height="90" width="120" />
+<description>Family health insurance now costs employers and workers nearly $20,000 a year, on average, according to a new report.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/3N8m4XT0qrk" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 10:02:47 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/03/news/economy/employer-health-insurance-cost/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>All eyes on Congress as vote on Kavanaugh draws near</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/fS9JwLh44nk/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/04/media/reliable-sources-10-03-18/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181003194636-kavanaugh-testifies-0927-120x90.jpg" height="90" width="120" />
+<description>The lead story for Thursday's morning shows: The impending vote to advance Brett Kavanaugh's nomination to the Supreme Court.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/fS9JwLh44nk" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Thu, 04 Oct 2018 00:47:47 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/04/media/reliable-sources-10-03-18/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>She was the first openly gay CEO at a Fortune 500 company</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/PAmyNhTyuog/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/01/news/companies/beth-ford-boss-files/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180727104314-beth-ford-land-o-lakes-120x90.jpg" height="90" width="120" />
+<description>Land O'Lakes CEO Beth Ford charts her career path, from her first job to becoming the first openly gay CEO at a Fortune 500 company in an interview with CNN's Boss Files.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/PAmyNhTyuog" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Tue, 02 Oct 2018 05:19:22 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/01/news/companies/beth-ford-boss-files/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Crypto companies are trying to cash in at a really bad time</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/0pKeXrlECGQ/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/09/27/technology/bitcoin-mining-ipo/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180124165635-should-i-buy-bitcoin-120x90.jpg" height="90" width="120" />
+<description>The world's top makers of bitcoin mining technology hope to raise money from investors by selling shares in Hong Kong.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/0pKeXrlECGQ" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 23:47:32 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/09/27/technology/bitcoin-mining-ipo/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>It's getting a lot harder for global brands to win in China</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/QvPU4bw6fH4/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/09/25/news/companies/brands-china-consumer/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180927123618-apple-store-zhejiang-greet-120x90.jpg" height="90" width="120" />
+<description>Changing tastes and the challenge from new Chinese rivals are forcing US and European companies including Apple and Starbucks to adopt new strategies to succeed in the world's second biggest economy.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/QvPU4bw6fH4" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 23:47:32 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/09/25/news/companies/brands-china-consumer/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Facebook doesn't think hackers accessed third-party sites</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/uYYwo4u05g0/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/technology/facebook-hack-third-party/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181001153815-100118-facebook-hacking-gfx-120x90.jpg" height="90" width="120" />
+<description>Read full story for latest details.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/uYYwo4u05g0" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Tue, 02 Oct 2018 23:49:45 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/technology/facebook-hack-third-party/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>A llama, bagel and frisbee: Apple's new iOS 12.1 emoji</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/tVlkipYCq-c/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/technology/apple-emoji-ios-12-1-llama/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002134214-100218-apple-emojis-gfx-120x90.jpg" height="90" width="120" />
+<description>A collection of new emoji is coming to iOS 12.1 for iPhone and iPad users, including food and cute animals.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/tVlkipYCq-c" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Tue, 02 Oct 2018 14:17:18 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/technology/apple-emoji-ios-12-1-llama/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Tencent Music aims to raise $1 billion by going public</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/-kmpoYc55R0/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/technology/business/tencent-music-ipo/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180709090119-tencent-headquarters-120x90.jpg" height="90" width="120" />
+<description>Tencent Music dominates the music streaming market in China through its Spotify-like apps.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/-kmpoYc55R0" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 00:11:33 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/technology/business/tencent-music-ipo/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Tesla needed some good news. These sales numbers help</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/NfLK0SRobL8/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/technology/tesla-sales/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002133722-01-tesla-model-3-1002-restricted-120x90.jpg" height="90" width="120" />
+<description>Read full story for latest details.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/NfLK0SRobL8" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 04:24:49 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/technology/tesla-sales/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>Volkswagen dumps jailed Audi CEO</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/jX98hg6VyEA/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/news/volkswagen-audi-rupert-stadler/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/180618101244-audi-ceo-rupert-stadler-120x90.jpg" height="90" width="120" />
+<description>Volkswagen has severed ties with suspended Audi CEO Rupert Stadler, who has been jailed since June in connection with an emissions investigation.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/jX98hg6VyEA" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Wed, 03 Oct 2018 06:04:17 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/news/volkswagen-audi-rupert-stadler/index.html?section=money_topstories</feedburner:origLink></item>
+<item>
+<title>S&amp;P downgrades debt-riddled GE and GE Capital</title>
+<link>http://rss.cnn.com/~r/rss/money_topstories/~3/Lp5v0-kd2nU/index.html</link>
+<guid isPermaLink="false">http://money.cnn.com/2018/10/02/investing/general-electric-downgrade-debt/index.html?section=money_topstories</guid>
+<media:thumbnail url="http://i2.cdn.turner.com/money/dam/assets/181002143051-100218-ge-underwater-120x90.jpg" height="90" width="120" />
+<description>New General Electric boss Larry Culp just got a fresh reminder of the debt-riddled balance sheet he's inheriting.&lt;img src="http://feeds.feedburner.com/~r/rss/money_topstories/~4/Lp5v0-kd2nU" height="1" width="1" alt=""/&gt;</description>
+<pubDate>Tue, 02 Oct 2018 14:48:59 EDT</pubDate>
+<feedburner:origLink>http://money.cnn.com/2018/10/02/investing/general-electric-downgrade-debt/index.html?section=money_topstories</feedburner:origLink></item>
+</channel></rss>

--- a/test/parsers/feedburner_rss2_entry_test.exs
+++ b/test/parsers/feedburner_rss2_entry_test.exs
@@ -6,11 +6,17 @@ defmodule ElixirFeedParser.Test.FeedburnerRSS2EntryTest do
 
   setup do
     example1_file = File.read!("test/fixtures/rss2/TechCrunch.xml")
+    example2_file = File.read!("test/fixtures/rss2/rsn_cnn.xml")
     example1 = with {:ok, xml} <- XmlNode.parse_string(example1_file), do: FeedburnerRSS2.parse(xml)
-    {:ok, [example1: List.first(example1.entries)]}
+    example2 = with {:ok, xml} <- XmlNode.parse_string(example2_file), do: FeedburnerRSS2.parse(xml)
+    {:ok, [example1: List.first(example1.entries), example2: List.first(example2.entries)]}
   end
 
   test "parse feed burner origLink", %{example1: feed} do
     assert feed.url == "http://techcrunch.com/2011/11/02/angies-list-prices-ipo-at-11-to-13-per-share-valued-at-over-600m/"
+  end
+
+  test "parse url for thumbnail", %{example2: feed} do
+    assert feed."rss2:thumbnail" == "http://i2.cdn.turner.com/money/dam/assets/170920161756-facebook-logo-wall-120x90.jpg"
   end
 end


### PR DESCRIPTION
RSS2 have been ignoring "media:thumbnail" element so I decided to add it so we can have url for that image. 

Added example file from this [site](http://rss.cnn.com/rss/money_topstories.rss) and test.