### PR TITLE
Return NIL instead of ERROR for unparsed date string

### DIFF
--- a/lib/parsers/helper.ex
+++ b/lib/parsers/helper.ex
@@ -1,6 +1,8 @@
 defmodule ElixirFeedParser.Parsers.Helper do
   alias ElixirFeedParser.XmlNode
 
+  require Logger
+
   def element(node, selector) do
     node |> XmlNode.find(selector) |> XmlNode.text
   end
@@ -25,8 +27,13 @@ defmodule ElixirFeedParser.Parsers.Helper do
         {:ok, date_time, _} = DateTime.from_iso8601(date_time_string)
         date_time
       "RFC_1123" -> 
-        {:ok, date_time} = Timex.parse(date_time_string, "{RFC1123}")
-        date_time
+        case Timex.parse(date_time_string, "{RFC1123}") do
+          {:ok, date_time} -> 
+            date_time
+          _ -> 
+            Logger.info("WARNING: unparsed date string (#{date_time_string})")
+            nil
+        end
     end
   end
 end


### PR DESCRIPTION
I've used `elixir-feed-parser` on a couple-dozen RSS feeds, and I've only seen it fail on http://elixirstatus.com/rss.  I believe that ElixirStatus uses some sort of German time format that isn't parsed properly by `Timex.parse`.  

On parse-failure, instead of raising an error, this change returns NIL, and logs a warning message.  This is a good behavior because IMO many or most aggregators ignore the feed dates anyway.   

THANKS for `elixir-feed-parser` it is super-useful.  :-)