### PR TITLE
Allow different date times in RSS2

### DIFF
--- a/lib/parsers/atom.ex
+++ b/lib/parsers/atom.ex
@@ -3,8 +3,6 @@ defmodule ElixirFeedParser.Parsers.Atom do
 
   alias ElixirFeedParser.XmlNode
 
-  @date_format "ISO_8601"
-
   def can_parse?(xml) do
     xml
     |> XmlNode.find("/feed")
@@ -34,7 +32,7 @@ defmodule ElixirFeedParser.Parsers.Atom do
       # TODO: add optional scheme and label attributes
       categories: feed |> elements("category", attr: "term"),
       contributors: feed |> elements("contributor/name"),
-      updated: feed |> element("updated") |> to_date_time(@date_format),
+      updated: feed |> element("updated") |> to_date_time(),
       generator: feed |> element("generator", attr: "uri"),
       icon: feed |> element("icon"),
       logo: feed |> element("logo"),
@@ -63,8 +61,8 @@ defmodule ElixirFeedParser.Parsers.Atom do
       authors: entry |> elements("author/name"),
       id: entry |> element("id"),
       title: entry |> element("title"),
-      updated: entry |> element("updated") |> to_date_time(@date_format),
-      published: entry |> element("published") |> to_date_time(@date_format),
+      updated: entry |> element("updated") |> to_date_time(),
+      published: entry |> element("published") |> to_date_time(),
 
       # TODO: add optional scheme and label attributes
       categories: entry |> elements("category", attr: "term"),

--- a/lib/parsers/helper.ex
+++ b/lib/parsers/helper.ex
@@ -3,6 +3,8 @@ defmodule ElixirFeedParser.Parsers.Helper do
 
   require Logger
 
+  @date_time_formats [:ISO_8601, :RFC_1123]
+
   def element(_node, []), do: nil
 
   def element(node, [selector | other_selectors]) do
@@ -28,7 +30,7 @@ defmodule ElixirFeedParser.Parsers.Helper do
     node |> XmlNode.map_children(selector, fn e -> XmlNode.attr(e, attr) end)
   end
 
-  def to_date_time(date_time_string), do: to_date_time(date_time_string, ["RFC_1123"])
+  def to_date_time(date_time_string), do: to_date_time(date_time_string, @date_time_formats)
   def to_date_time(nil, _), do: nil
 
   def to_date_time(date_time_string, format) when is_binary(format),
@@ -39,14 +41,14 @@ defmodule ElixirFeedParser.Parsers.Helper do
     nil
   end
 
-  def to_date_time(date_time_string, ["ISO_8601" | other_formats]) do
+  def to_date_time(date_time_string, [:ISO_8601 | other_formats]) do
     case DateTime.from_iso8601(date_time_string) do
       {:ok, date_time, _} -> date_time
       {:error, _} -> to_date_time(date_time_string, other_formats)
     end
   end
 
-  def to_date_time(date_time_string, ["RFC_1123" | other_formats]) do
+  def to_date_time(date_time_string, [:RFC_1123 | other_formats]) do
     case Timex.parse(date_time_string, "{RFC1123}") do
       {:ok, date_time} -> date_time
       {:error, _} -> to_date_time(date_time_string, other_formats)

--- a/lib/parsers/helper.ex
+++ b/lib/parsers/helper.ex
@@ -3,6 +3,15 @@ defmodule ElixirFeedParser.Parsers.Helper do
 
   require Logger
 
+  def element(_node, []), do: nil
+
+  def element(node, [selector | other_selectors]) do
+    case element(node, selector) do
+      nil -> element(node, other_selectors)
+      result -> result
+    end
+  end
+
   def element(node, selector) do
     node |> XmlNode.find(selector) |> XmlNode.text()
   end
@@ -19,24 +28,28 @@ defmodule ElixirFeedParser.Parsers.Helper do
     node |> XmlNode.map_children(selector, fn e -> XmlNode.attr(e, attr) end)
   end
 
-  def to_date_time(date_time_string), do: to_date_time(date_time_string, "RFC_1123")
+  def to_date_time(date_time_string), do: to_date_time(date_time_string, ["RFC_1123"])
   def to_date_time(nil, _), do: nil
 
-  def to_date_time(date_time_string, format) do
-    case format do
-      "ISO_8601" ->
-        {:ok, date_time, _} = DateTime.from_iso8601(date_time_string)
-        date_time
+  def to_date_time(date_time_string, format) when is_binary(format),
+    do: to_date_time(date_time_string, [format])
 
-      "RFC_1123" ->
-        case Timex.parse(date_time_string, "{RFC1123}") do
-          {:ok, date_time} ->
-            date_time
+  def to_date_time(date_time_string, []) do
+    Logger.info("WARNING: unparsed date string (#{date_time_string})")
+    nil
+  end
 
-          _ ->
-            Logger.info("WARNING: unparsed date string (#{date_time_string})")
-            nil
-        end
+  def to_date_time(date_time_string, ["ISO_8601" | other_formats]) do
+    case DateTime.from_iso8601(date_time_string) do
+      {:ok, date_time, _} -> date_time
+      {:error, _} -> to_date_time(date_time_string, other_formats)
+    end
+  end
+
+  def to_date_time(date_time_string, ["RFC_1123" | other_formats]) do
+    case Timex.parse(date_time_string, "{RFC1123}") do
+      {:ok, date_time} -> date_time
+      {:error, _} -> to_date_time(date_time_string, other_formats)
     end
   end
 end

--- a/lib/parsers/rss2.ex
+++ b/lib/parsers/rss2.ex
@@ -67,6 +67,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
         entry
         |> element([
           "pubDate",
+          "pubdate",
           "publicationDate",
           "dcterms:created",
           "dc:date",
@@ -78,6 +79,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
         entry
         |> element([
           "pubDate",
+          "pubdate",
           "publicationDate",
           "dcterms:created",
           "dc:date",

--- a/lib/parsers/rss2.ex
+++ b/lib/parsers/rss2.ex
@@ -3,8 +3,6 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
 
   alias ElixirFeedParser.XmlNode
 
-  @date_format ["RFC_1123", "ISO_8601"]
-
   def can_parse?(xml) do
     xml
     |> XmlNode.find("/rss")
@@ -30,9 +28,9 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
       "rss2:managingEditor": feed |> element("managingEditor"),
       "rss2:webMaster": feed |> element("webMaster"),
       # TODO: also work with pubdate or publicationDate
-      updated: feed |> element("pubDate") |> to_date_time(@date_format),
-      "rss2:pubDate": feed |> element("pubDate") |> to_date_time(@date_format),
-      "rss2:lastBuildDate": feed |> element("lastBuildDate") |> to_date_time(@date_format),
+      updated: feed |> element("pubDate") |> to_date_time(),
+      "rss2:pubDate": feed |> element("pubDate") |> to_date_time(),
+      "rss2:lastBuildDate": feed |> element("lastBuildDate") |> to_date_time(),
       categories: feed |> elements("category"),
       generator: feed |> element("generator"),
       "rss2:ttl": feed |> element("ttl"),
@@ -74,7 +72,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
           "dc:Date",
           "a10:updated"
         ])
-        |> to_date_time(@date_format),
+        |> to_date_time(),
       "rss2:pubDate":
         entry
         |> element([
@@ -86,7 +84,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
           "dc:Date",
           "a10:updated"
         ])
-        |> to_date_time(@date_format),
+        |> to_date_time(),
       source: entry |> element("source", attr: "url"),
       content: entry |> element("content:encoded"),
       enclosure: entry |> XmlNode.find("enclosure") |> parse_enclosure

--- a/lib/parsers/rss2.ex
+++ b/lib/parsers/rss2.ex
@@ -3,7 +3,7 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
 
   alias ElixirFeedParser.XmlNode
 
-  @date_format "RFC_1123"
+  @date_format ["RFC_1123", "ISO_8601"]
 
   def can_parse?(xml) do
     xml
@@ -63,9 +63,14 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
       id: entry |> element("guid"),
       "rss2:guid": entry |> element("guid"),
       comments: entry |> element("comments"),
-      # TODO: also work with pubdate or publicationDate, dc:date, dc:Date, dcterms:created
-      updated: entry |> element("pubDate") |> to_date_time(@date_format),
-      "rss2:pubDate": entry |> element("pubDate") |> to_date_time(@date_format),
+      updated:
+        entry
+        |> element(["pubDate", "publicationDate", "dcterms:created", "dc:date", "dc:Date"])
+        |> to_date_time(@date_format),
+      "rss2:pubDate":
+        entry
+        |> element(["pubDate", "publicationDate", "dcterms:created", "dc:date", "dc:Date"])
+        |> to_date_time(@date_format),
       source: entry |> element("source", attr: "url"),
       content: entry |> element("content:encoded"),
       enclosure: entry |> XmlNode.find("enclosure") |> parse_enclosure

--- a/lib/parsers/rss2.ex
+++ b/lib/parsers/rss2.ex
@@ -65,11 +65,25 @@ defmodule ElixirFeedParser.Parsers.RSS2 do
       comments: entry |> element("comments"),
       updated:
         entry
-        |> element(["pubDate", "publicationDate", "dcterms:created", "dc:date", "dc:Date"])
+        |> element([
+          "pubDate",
+          "publicationDate",
+          "dcterms:created",
+          "dc:date",
+          "dc:Date",
+          "a10:updated"
+        ])
         |> to_date_time(@date_format),
       "rss2:pubDate":
         entry
-        |> element(["pubDate", "publicationDate", "dcterms:created", "dc:date", "dc:Date"])
+        |> element([
+          "pubDate",
+          "publicationDate",
+          "dcterms:created",
+          "dc:date",
+          "dc:Date",
+          "a10:updated"
+        ])
         |> to_date_time(@date_format),
       source: entry |> element("source", attr: "url"),
       content: entry |> element("content:encoded"),

--- a/test/fixtures/rss2/iso_date_in_rss2.xml
+++ b/test/fixtures/rss2/iso_date_in_rss2.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" media="screen" href="/~d/styles/rss2full.xsl"?><?xml-stylesheet type="text/css" media="screen" href="http://feeds.feedburner.com/~d/styles/itemcontent.css"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:admin="http://webns.net/mvcb/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
+
+    <channel>
+    
+    <title>LM Editorial</title>
+    <link>http://www.logisticsmgmt.com</link>
+    <description />
+    <dc:language>en</dc:language>
+    <dc:creator>kwhorisk@ehpub.com</dc:creator>
+    <dc:rights>Copyright 2022</dc:rights>
+    <dc:date>2022-06-02T16:45:00+00:00</dc:date>
+    <admin:generatorAgent rdf:resource="http://expressionengine.com/" />
+    
+
+    <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="http://feeds.feedburner.com/lm/rss/recentlyfiled" /><feedburner:info xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" uri="lm/rss/recentlyfiled" /><atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/" /><item>
+      <title>U.S. retail sales see slight May decline</title>
+      <link>https://www.logisticsmgmt.com/article/u.s._retail_sales_see_slight_may_decline</link>
+      <guid>https://www.logisticsmgmt.com/article/u.s._retail_sales_see_slight_may_decline#When:16:11:00Z</guid>
+      <description>Commerce reported that May retail sales—at $672.9 billion—were down 0.3% compared to April, while seeing an 8.1% annual gain. NRF said that in its calculation of retail sales, which excludes automobile dealers, gasoline stations, and restaurants, to focus on core retail, pointed to May retail sales being flat on a seasonally-adjusted basis compared to April and up 6.7% on an unadjusted basis annually.</description>
+      <dc:subject>News, Logistics, 3PL, Transportation, Warehouse, Warehouse/DC,</dc:subject>
+      <dc:date>2022-06-15T16:11:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>STB says U.S. Class I railroads’ service recovery plans need more detail</title>
+      <link>https://www.logisticsmgmt.com/article/stb_says_u.s._class_i_railroads_service_recovery_plans_need_more_detail</link>
+      <guid>https://www.logisticsmgmt.com/article/stb_says_u.s._class_i_railroads_service_recovery_plans_need_more_detail#When:15:33:00Z</guid>
+      <description>The close eye being kept on service levels remains fully intact based on a directive by the Washington, D.C.-based Surface Transportation Board (STB), to BNSF Railway Company (BNSF), CSX Transportation, Inc. (CSX), Norfolk Southern Railway (NSR), and Union Pacific Railroad (UP).</description>
+      <dc:subject>News, Logistics, 3PL, Transportation, Rail &amp;amp; Intermodal,</dc:subject>
+      <dc:date>2022-06-15T15:33:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>May Cass Freight Index shows further continuation of freight shipment and expenditure trends</title>
+      <link>https://www.logisticsmgmt.com/article/may_cass_freight_index_shows_further_continuation_of_freight_shipment_and_e</link>
+      <guid>https://www.logisticsmgmt.com/article/may_cass_freight_index_shows_further_continuation_of_freight_shipment_and_e#When:14:02:00Z</guid>
+      <description>May’s shipment reading—at 1.235—fell 2.7% annually, which was steeper than April’s 0.5% annual decline. And May expenditures—at 4.287—were up 27.5% annually, in line with April’s 30.6% annual gain and continuing to be paced by major inflation gains.</description>
+      <dc:subject>News,</dc:subject>
+      <dc:date>2022-06-15T14:02:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>National diesel average, for week of June 13, hits another record-high</title>
+      <link>https://www.logisticsmgmt.com/article/national_diesel_average_for_week_of_june_13_hits_another_record_high</link>
+      <guid>https://www.logisticsmgmt.com/article/national_diesel_average_for_week_of_june_13_hits_another_record_high#When:19:42:00Z</guid>
+      <description>The national average for the national average price per gallon of diesel gasoline came in at $5.718 per gallon, according to data published this week by the Department of Energy’s Energy Information Administration (EIA).</description>
+      <dc:subject>News,</dc:subject>
+      <dc:date>2022-06-14T19:42:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>ILWU and PMA expect labor negotiations to go past July 1 deadline</title>
+      <link>https://www.logisticsmgmt.com/article/ilwu_and_pma_expect_labor_negotiations_to_go_past_july_1_deadline</link>
+      <guid>https://www.logisticsmgmt.com/article/ilwu_and_pma_expect_labor_negotiations_to_go_past_july_1_deadline#When:19:24:00Z</guid>
+      <description>As negotiations continue between the International Longshore Warehouse Union (ILWU) and the Pacific Maritime Association (PMA), with their current contract set to expire at the end of June, the organizations said in a joint statement issued today that “they are unlikely to reach a deal before the July 1 expiration of the current agreement.”</description>
+      <dc:subject>News,</dc:subject>
+      <dc:date>2022-06-14T19:24:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>FREE Download: The Complete 2022 Salary Survey Report</title>
+      <link>https://www.logisticsmgmt.com/article/free_download_the_complete_2022_salary_survey_report</link>
+      <guid>https://www.logisticsmgmt.com/article/free_download_the_complete_2022_salary_survey_report#When:18:57:00Z</guid>
+      <description>Logistics Management is proud to offer the complete results and analysis of our 38th Annual Salary Survey.</description>
+      <dc:subject>Resources, White Papers, Logistics, E-commerce, Global Trade, Sustainability, Transportation, Air Freight, Motor Freight, Ocean Freight, Ports, Rail &amp;amp; Intermodal, Warehouse, Automation, Warehouse/DC, Technology, Cloud, IoT, Mobile &amp; Wireless, Software,</dc:subject>
+      <dc:date>2022-06-14T18:57:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>U.S. House passes the Ocean Shipping Reform Act, with Biden set to sign it into law</title>
+      <link>https://www.logisticsmgmt.com/article/u.s._house_passes_the_ocean_shipping_reform_act_with_biden_set_to_sign_it_i</link>
+      <guid>https://www.logisticsmgmt.com/article/u.s._house_passes_the_ocean_shipping_reform_act_with_biden_set_to_sign_it_i#When:16:26:00Z</guid>
+      <description>Following its passage by the U.S. Senate in late March, the U.S. House of Representatives last night followed suit, passing the Ocean Shipping Reform Act (OSRA) of 2022 by a 369-42 margin. The bill is now headed to President Biden’s desk to be signed into law, and will represent the first revamping of U.S. ocean shipping laws going back to 1998.</description>
+      <dc:subject>News, Logistics, 3PL, Global Trade, Transportation, Motor Freight, Ocean Freight, Rail &amp;amp; Intermodal,</dc:subject>
+      <dc:date>2022-06-14T16:26:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>Proposed speed limiter regulation draws more than 15,500 comments to FMCSA</title>
+      <link>https://www.logisticsmgmt.com/article/proposed_speed_limiter_regulation_draws_more_than_15500_comments_to_fmcsa</link>
+      <guid>https://www.logisticsmgmt.com/article/proposed_speed_limiter_regulation_draws_more_than_15500_comments_to_fmcsa#When:07:22:00Z</guid>
+      <description>Federal regulators working on a proposal that would create a nationwide truck speed limit using electronic engine devices last week extended the comment period on the controversial move by six weeks, to July 18.</description>
+      <dc:subject>News,</dc:subject>
+      <dc:date>2022-06-14T07:22:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>Prologis set to acquire Duke Realty through $26 billion all-stock deal</title>
+      <link>https://www.logisticsmgmt.com/article/prologis_set_to_acquire_duke_realty_through_26_billion_all_stock_deal</link>
+      <guid>https://www.logisticsmgmt.com/article/prologis_set_to_acquire_duke_realty_through_26_billion_all_stock_deal#When:16:44:00Z</guid>
+      <description>Following its most recent overture in early May, which was denied, San Francisco-based real estate investment trust company Prologis said it had finally closed the deal, announcing it had entered into a definitive merger agreement to acquire Indianapolis-based Duke Realty Corporation, a sustainable industrial real estate development and the largest domestic-only logistics REIT (Real Estate Investment Trust).</description>
+      <dc:subject>News, Logistics, 3PL, Warehouse, Warehouse/DC,</dc:subject>
+      <dc:date>2022-06-13T16:44:00+00:00</dc:date>
+    </item>
+
+    <item>
+      <title>POLA, POLB again push back consideration of container dwell fee June 17</title>
+      <link>https://www.logisticsmgmt.com/article/pola_polb_again_push_back_consideration_of_container_dwell_fee_june_17</link>
+      <guid>https://www.logisticsmgmt.com/article/pola_polb_again_push_back_consideration_of_container_dwell_fee_june_17#When:15:22:00Z</guid>
+      <description>This follows previous joint announcements by POLA and POLB, whom collectively account for roughly 40% of United States-bound import volumes, indicating that consideration of the fee would be pushed back each week going back to the week of November 22, 2021.</description>
+      <dc:subject>News, Logistics, 3PL, Transportation, Ocean Freight, Ports,</dc:subject>
+      <dc:date>2022-06-13T15:22:00+00:00</dc:date>
+    </item>
+
+    
+    </channel>
+</rss>

--- a/test/parsers/feedburner_rss2_entry_test.exs
+++ b/test/parsers/feedburner_rss2_entry_test.exs
@@ -7,6 +7,7 @@ defmodule ElixirFeedParser.Test.FeedburnerRSS2EntryTest do
   setup do
     example1_file = File.read!("test/fixtures/rss2/TechCrunch.xml")
     example2_file = File.read!("test/fixtures/rss2/rsn_cnn.xml")
+    example3_file = File.read!("test/fixtures/rss2/iso_date_in_rss2.xml")
 
     example1 =
       with {:ok, xml} <- XmlNode.parse_string(example1_file), do: FeedburnerRSS2.parse(xml)
@@ -14,7 +15,15 @@ defmodule ElixirFeedParser.Test.FeedburnerRSS2EntryTest do
     example2 =
       with {:ok, xml} <- XmlNode.parse_string(example2_file), do: FeedburnerRSS2.parse(xml)
 
-    {:ok, [example1: List.first(example1.entries), example2: List.first(example2.entries)]}
+    example3 =
+      with {:ok, xml} <- XmlNode.parse_string(example3_file), do: FeedburnerRSS2.parse(xml)
+
+    {:ok,
+     [
+       example1: List.first(example1.entries),
+       example2: List.first(example2.entries),
+       example3: List.first(example3.entries)
+     ]}
   end
 
   test "parse feed burner origLink", %{example1: feed} do
@@ -25,5 +34,9 @@ defmodule ElixirFeedParser.Test.FeedburnerRSS2EntryTest do
   test "parse url for thumbnail", %{example2: feed} do
     assert feed."rss2:thumbnail" ==
              "http://i2.cdn.turner.com/money/dam/assets/170920161756-facebook-logo-wall-120x90.jpg"
+  end
+
+  test "parse iso date even in rss2 with dc:date", %{example3: feed} do
+    assert feed.updated == ~U[2022-06-15 16:11:00Z]
   end
 end


### PR DESCRIPTION
Some RSS2 feedburner articles aren't being parsed correctly because they use `dc:date` in ISO format, this PR fixes that so more articles can be parsed.

I added a test with an article that couldn't be parsed before